### PR TITLE
fix(ci): gate tag creation behind tests in tag.yml

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,54 +1,100 @@
-name: Tag
+name: Tag and Publish
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
     branches: [main]
 
 jobs:
-  tag:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+  check-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      actions: write
+    outputs:
+      should_release: ${{ steps.version.outputs.should_release }}
+      version: ${{ steps.version.outputs.current }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
-      - name: Check version
+
+      - name: Check version status
         id: version
         run: |
           CURRENT_VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
           echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
           if curl -s "https://pypi.org/pypi/django-iconx/$CURRENT_VERSION/json" | grep -q '"version"'; then
-            echo "on_pypi=true" >> $GITHUB_OUTPUT
-          else
-            echo "on_pypi=false" >> $GITHUB_OUTPUT
+            echo "should_release=false" >> $GITHUB_OUTPUT
+            echo "Version $CURRENT_VERSION already on PyPI — nothing to do"
+            exit 0
           fi
+
+          # Tag-exists is treated as "do nothing"; a broken tag must be deleted
+          # manually before a re-release. Auto-retrying on an existing tag is how
+          # we got stuck publishing the same broken commit repeatedly.
           git fetch --tags
           if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
-            echo "tag_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "tag_exists=false" >> $GITHUB_OUTPUT
+            echo "should_release=false" >> $GITHUB_OUTPUT
+            echo "Tag v$CURRENT_VERSION already exists — delete it manually to re-release"
+            exit 0
           fi
+
+          echo "should_release=true" >> $GITHUB_OUTPUT
+          echo "Will release v$CURRENT_VERSION after tests pass"
+
+  test:
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run ruff check
+        run: uv run ruff check
+
+      - name: Run ruff format check
+        run: uv run ruff format --check
+
+      - name: Run mypy check
+        run: uv run mypy django_iconx/
+
+      - name: Run tests
+        run: uv run pytest -n auto
+
+  tag-and-trigger:
+    needs: [check-version, test]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    env:
+      VERSION: ${{ needs.check-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
       - name: Create and push tag
-        if: steps.version.outputs.on_pypi == 'false' && steps.version.outputs.tag_exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v${{ steps.version.outputs.current }}"
-          git push origin "v${{ steps.version.outputs.current }}"
-      - name: Trigger publish
-        if: steps.version.outputs.on_pypi == 'false'
-        run: gh workflow run publish.yml -f version=${{ steps.version.outputs.current }} -R ${{ github.repository }}
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+      # GITHUB_TOKEN-pushed tags don't trigger downstream workflows — explicit
+      # dispatch is required.
+      - name: Trigger publish workflow
+        run: gh workflow run publish.yml -f version=$VERSION -R ${{ github.repository }}
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Trigger docs
-        if: steps.version.outputs.on_pypi == 'false' && steps.version.outputs.tag_exists == 'false'
-        run: gh workflow run docs.yml --ref "v${{ steps.version.outputs.current }}" -R ${{ github.repository }}
+
+      - name: Trigger docs workflow for new tag
+        run: gh workflow run docs.yml --ref "v$VERSION" -R ${{ github.repository }}
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Replaces `.github/workflows/tag.yml` with a 3-job pattern (`check-version` → `test` → `tag-and-trigger`) that gates tag creation on tests passing in the same workflow, and treats an existing tag as a hard stop instead of auto-retriggering publish.

The previous design had two flaws:

- `Trigger publish` was gated only on `on_pypi == 'false'`, missing the `&& tag_exists == 'false'` clause. Any push to main after a publish failure would re-trigger publish on the stale tag forever — same SHA, same failure, no way for fresh fixes on main to be picked up.
- The test gate lived in a separate workflow (`workflow_run: ["CI"]`). It worked for the primary case but is brittle — renaming or restructuring CI silently breaks the gate.

The new design follows the same shape as [`django-filthyfields/.github/workflows/tag.yml`](https://github.com/oliverhaas/django-filthyfields/blob/main/.github/workflows/tag.yml).

## Test plan

- [ ] Workflow YAML parses cleanly (GitHub Actions linter)
- [ ] Next push to `main` runs `check-version`; if no version bump, no further jobs run
- [ ] On a real version bump: confirm `test` runs before the tag is pushed, and that an existing tag with no PyPI release is now a no-op (no auto-retry of publish)